### PR TITLE
Better accessibility w/ hidden attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,9 @@ If you want to use a different timing function, add some CSS for your `<slide-up
 
 ### Listening for Events
 
-To keep the codebase _small, but powerful™_, this package doesn't provide hooks for `transitionend`, `transitionstart` or other events, but instead provides direct access to the DOM Element that does the actual sliding up and down:
+The component emits four Vue events, `open-start`, `open-end`, `close-start`, `close-end`. E.g. `<vue-slide-up-down @close-end="console.log('done closing!')" ...`
+
+Alternatively, one can also add a ref and listen for the `transitionend` event.
 
 Add a [`ref`](https://vuejs.org/v2/api/#vm-refs) to your SlideUpDown-Element:
 

--- a/src/slide-up-down.js
+++ b/src/slide-up-down.js
@@ -15,7 +15,8 @@ export default {
 
   data: () => ({
     style: {},
-    initial: false
+    initial: false,
+    hidden: !this.active
   }),
 
   watch: {
@@ -29,23 +30,15 @@ export default {
       this.tag,
       {
         style: this.style,
-        ref: 'container'
+        ref: 'container',
+        attrs: { hidden: this.hidden },
+        on: { transitionend: this.onTransitionEnd }
       },
       this.$slots.default
     )
   },
 
   mounted () {
-    this.el.addEventListener('transitionend', () => {
-      if (this.active) {
-        this.style = {}
-      } else {
-        this.style = {
-          height: '0',
-          overflow: 'hidden'
-        }
-      }
-    })
     this.layout()
     this.initial = true
   },
@@ -59,10 +52,13 @@ export default {
   methods: {
     layout () {
       if (this.active) {
+        this.hidden = false
+        this.$emit('open-start')
         if (this.initial) {
           this.setHeight('0px', () => this.el.scrollHeight + 'px')
         }
       } else {
+        this.$emit('close-start')
         this.setHeight(this.el.scrollHeight + 'px', () => '0px')
       }
     },
@@ -89,6 +85,20 @@ export default {
           'transition-duration': this.duration + 'ms'
         }
       })
+    },
+
+    onTransitionEnd () {
+      if (this.active) {
+        this.style = {}
+        this.$emit('open-end')
+      } else {
+        this.style = {
+          height: '0',
+          overflow: 'hidden'
+        }
+        this.hidden = true
+        this.$emit('close-end')
+      }
     }
   }
 }


### PR DESCRIPTION
While testing keyboard accessibility we found that hidden content was still tab-able. This PR sets the hidden attribute after content has closed and removes it when the content starts to open. 

... Also, at the risk of stepping on the toes of  _small, but powerful™_, I think this component would benefit from emitting some events. Listening to the `transitionend` event directly through the DOM element feels a little antiquated, at I _really_ don't think it bloats the component at all. 