### PR TITLE
option for disable slide-up-down

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The component takes four props:
 - `active` (Boolean, required): Whether to show the component (`true`) or not (`false`)
 - `duration` (Number, optional): How long the animation is supposed to be, in milliseconds. Defaults to `500`.
 - `tag` (String, optional): Which HTML tag to use for the wrapper element. Defaults to `div`.
+- `active` (Boolean, optional): Disable slide-up-down. Defaults to `false`
 - `use-hidden` (Boolean, optional): Whether to apply the "hidden" attribute to the element when closed. Defaults to `true`. This hides the component from the screen and from assistive devices. The internal elements of the component are completely invisible, and cannot be focused on (by a keyboard or assistive device). (This is probably what you want!) If you need, set this property to `false` to not use the `hidden` attribute. This could be used if you wanted to have a min-height requirement on your component. **⚠️ Note that this can create accessibility issues**, specifically for users with a keyboard or screen reader. Even though the component may _appear_ hidden, focusable elements within the component are still able to be accessed through keyboard navigation.
 
 ```html

--- a/src/slide-up-down.js
+++ b/src/slide-up-down.js
@@ -15,6 +15,10 @@ export default {
       type: Boolean,
       default: true,
     },
+    disabled: {
+      type: Boolean,
+      default: false
+    },
   },
 
   data: () => ({
@@ -33,7 +37,7 @@ export default {
     return h(
       this.tag,
       {
-        style: this.style,
+        style: this.renderStyle,
         attrs: this.attrs,
         ref: 'container',
         on: { transitionend: this.onTransitionEnd },
@@ -66,8 +70,11 @@ export default {
         attrs.hidden = this.hidden
       }
 
-      return attrs
+      return !this.disabled ? attrs : {}
     },
+    renderStyle() {
+      return !this.disabled ? this.style : {}
+    }
   },
 
   methods: {


### PR DESCRIPTION
For example, in the desktop version i open menu on hover.
```
.menu {
    .sub-menu {
        display: none;
    }

    &:hover {
        .sub-menu {
            display: block;
        }
    }
}
```

But on the mobile version i use click to open menu via slide-up-down
```
<div class="menu">
    <div @click="showed = !showed" class="title"></div>
    <slide-up-down :active="showed" class="sub-menu"></slide-up-down>
</div>
```

When user change screen resolution from desktop to mobile(rotate phone from landscape to portrait) and back it cause bug because slide-up-down set height:0px, cause it use el.scrollHeight, that equal to zero on display:none element

So we can use `disabled` option to remove unnecessary and buggy(height: 0px) styles and attrs on desktop version

```
<slide-up-down :disabled="isDesktop" :active="showed" :duration="150">
isDesktop = window.innerWidth >= 400
```